### PR TITLE
minimum output for crafted amulets 92 -> 90

### DIFF
--- a/D2Etal/scripts/libs/common/NTCubing.ntl
+++ b/D2Etal/scripts/libs/common/NTCubing.ntl
@@ -120,7 +120,7 @@ _NTCU_CraftRecipe.push([79, 618, 561]);
 _NTCU_CraftRecipe.push([85, 615, 561]);
 _NTCU_CraftRecipe.push([82, 614, 561]);
 _NTCU_CraftRecipe.push([85, 616, 561]);
-_NTCU_CraftRecipe.push([92, 617, 561]);
+_NTCU_CraftRecipe.push([90, 617, 561]);
 _NTCU_CraftRecipe.push([86, 620, 561]);
 _NTCU_CraftRecipe.push([85, 612, 561]);
 


### PR DESCRIPTION
Having it at 92 creates potential problems when gambling for crafting amulets is enabled. This is because gambling for the base amulet is configured for a minimum of 90.
