### PR TITLE
Fix default aura while HolyBolt is used

### DIFF
--- a/D2Etal/scripts/NTBot/bots/NTWorldStoneKeep.ntj
+++ b/D2Etal/scripts/NTBot/bots/NTWorldStoneKeep.ntj
@@ -406,6 +406,7 @@ function achmel(){
 			else
 				NTM_WalkTo(me.x-10, me.y);
 		}
+		NTC_PutSkill(NTConfig_AttackSkill[6], NTC_HAND_RIGHT);
 	}
 	var _company = NTC_FindUnit(NTC_UNIT_MONSTER, 105);
 	do{
@@ -421,6 +422,7 @@ function achmel(){
 				else
 					NTM_WalkTo(me.x-10, me.y);
 			}
+		NTC_PutSkill(NTConfig_AttackSkill[6], NTC_HAND_RIGHT);
 		}
 	} while (_company && _company.GetNext());
 }


### PR DESCRIPTION
While moving bot is using Vigor after it finds good spot it's not changing aura back to default and this should fix it.
Tested only on Pal.
