### PR TITLE
NTTM_GCCheckAmu() - added checks for gold to prevent infinite loop

### DIFF
--- a/D2Etal/scripts/libs/common/NTTownManager.ntl
+++ b/D2Etal/scripts/libs/common/NTTownManager.ntl
@@ -1604,7 +1604,7 @@ function NTTM_GCCheckAmu(){
 
 		if(_npc)
 		{
-			while(!NTTM_GCHaveAmu()){
+			while(!NTTM_GCHaveAmu() && NTC_MyGold() > NTConfig_GCAmuGold){
 				if(NTT_DoInteract(_npc))
 				{
 					if(NTT_DoTrade(_npc, 1))
@@ -1628,7 +1628,7 @@ function NTTM_GCCheckAmu(){
 
 		if(_npc)
 		{
-			while(!NTTM_GCHaveAmu()){
+			while(!NTTM_GCHaveAmu() && NTC_MyGold() > NTConfig_GCAmuGold){
 				if(NTT_DoInteract(_npc))
 				{
 					if(NTT_DoTrade(_npc, 1))
@@ -1652,7 +1652,7 @@ function NTTM_GCCheckAmu(){
 
 		if(_npc)
 		{
-			while(!NTTM_GCHaveAmu()){
+			while(!NTTM_GCHaveAmu() && NTC_MyGold() > NTConfig_GCAmuGold){
 				if(NTT_DoInteract(_npc))
 				{
 					if(NTT_DoTrade(_npc, 1))
@@ -1677,7 +1677,7 @@ function NTTM_GCCheckAmu(){
 
 		if(_npc)
 		{
-			while(!NTTM_GCHaveAmu()){
+			while(!NTTM_GCHaveAmu() && NTC_MyGold() > NTConfig_GCAmuGold){
 				if(NTT_DoInteract(_npc))
 				{
 					if(NTT_DoTrade(_npc, 1))
@@ -1702,7 +1702,7 @@ function NTTM_GCCheckAmu(){
 
 		if(_npc)
 		{
-			while(!NTTM_GCHaveAmu()){
+			while(!NTTM_GCHaveAmu() && NTC_MyGold() > NTConfig_GCAmuGold){
 				if(NTT_DoInteract(_npc))
 				{
 					if(NTT_DoTrade(_npc, 1))


### PR DESCRIPTION
Added gold checks to prevent infinite loop.

This can occur commonly on characters that are at or slightly above the minimum clvl to gamble suitable amulets for crafting. This may also occur rarely on any lvl character if they repeatedly gamble rare quality amulets until they run out of gold.

The config'd gold amount for amulet gambling highly effects these scenarios. I preferred to have a lower amount set, so my bot gets its amulet asap and can start collecting gems/runes asap.
